### PR TITLE
F: guess test framework bug fix

### DIFF
--- a/lib/adapt.js
+++ b/lib/adapt.js
@@ -4,9 +4,9 @@ var common = require('totoro-common')
 var logger = require('./logger')
 
 var defaultAdapters = getDefaultAdapters()
-var adapterReg = new RegExp('<script.*?(' +
+var adapterReg = new RegExp('<script[\\s\\S]*?(' +
         defaultAdapters.join('|') +
-        ').*?>.*?<\/script>', 'ig' )
+        ')[\\s\\S]*?>[\s]*?<\/script>', 'ig' );
 
 
 module.exports = adapt
@@ -78,7 +78,7 @@ function getInsertPos(content, adapter) {
     var pos
     var matched
     if (common.isKeyword(adapter)) {
-        var reg = new RegExp('<script.*?' + adapter + '.*?>.*?<\/script>', 'ig' )
+        var reg = new RegExp('<script[\\s\\S]*?' + adapter + '[\\s\\S]*?>[\s]*?<\/script>', 'ig' )
         while((matched = reg.exec(content)) !== null) {
             pos = matched.index +  matched[0].length
         }


### PR DESCRIPTION
当使用下面的方式引用JS的时候，无法判断出是使用了mocha，修改正则适应下面的情况

``` html
<script
src="http://assets.spmjs.org/??
gallery/mocha/1.9.0/mocha.js,
jquery/jquery/1.7.2/jquery.js"></script>
```

同时默认只识别mocha和jasmine通过 **外部链接的形式** 引入，也就是假设
script开头和结尾标签之间除了空格换行，也就是`[\s]*?`
