### PR TITLE
exports logger

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,3 +123,5 @@ Server.prototype.launchServer = function() {
 function mainVersion(v){
   return v.substring(0, v.lastIndexOf('.'))
 }
+
+module.exports.logger = logger


### PR DESCRIPTION
方便在第三方调用的时候,可以设置 logger 显示级别, 避免显示过多无用日志.

```
  Server.logger.setLevel('warn');
```
